### PR TITLE
Added three new modes: pass through, pick first n, pick last n

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,4 +149,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This uses only regular nodes and the Unified Chooser. If you're going to try the
 |![workflow](docs/Screenshot%20both.png)|![dog](docs/both.png)
 
 ## Recent changes
+2.8 (6 Dec 2023)
+- added three new modes: pass through, take first n, take last n
 
 2.7 (4 Dec 2023)
 - various minor fixes

--- a/image_chooser_preview.py
+++ b/image_chooser_preview.py
@@ -61,7 +61,9 @@ class PreviewAndChoose(PreviewImage):
 
         # wait for selection
         try:
-            selections = MessageHolder.waitForMessage(id, asList=True) if (mode=="Always pause" or self.batch>1 and mode not in ["Pass through", "Take First n", "Take Last n"]) else [0]
+            is_block_condition = (mode == "Always pause" or self.batch > 1)
+            is_blocking_mode = (mode not in ["Pass through", "Take First n", "Take Last n"])
+            selections = MessageHolder.waitForMessage(id, asList=True) if (is_blocking_mode and is_block_condition) else [0]
         except Cancelled:
             return (None, None,)
         


### PR DESCRIPTION
I added three new modes to the very awesome preview-chooser node. I made these because they were useful for my workflows.

**Pass through:** 
- Does not pause the execution
- Simply passes on all images and latents from the inputs to the outputs
Main use case: 
- When using multiple preview-chooser nodes in our workflow, we are able to select and pause only specific ones.
- We are still able to preview and restart any generated images later on (even from the pass through nodes)
- When constructing complex modular workflows, place preview-chooser nodes in front of each module. This allows us to restart the execution of each module without restarting the entire workflow.

**Pick first n:**
- Does not pause the execution
- Automatically picks the first n images and latents and passes them on to the outputs
- n is specified via the new count field and the default is 1
Main use case:
- Allows us to select images automatically when we know they will be first in the batch (e.g. computed Masks)

**Pick last n:**
- Does not pause the execution
- Automatically picks the last n images and latents and passes them on to the outputs
- n is specified via the new count field and the default is 1
Main use case:
- Allows us to select images automatically when we know they will be last in the batch (e.g. computed Masks)