### PR TITLE
Added new hud position options

### DIFF
--- a/js/image_chooser.js
+++ b/js/image_chooser.js
@@ -137,6 +137,13 @@ app.registerExtension({
         Additional settings
         */
         app.ui.settings.addSetting({
+            id: "ImageChooser.hudVisbility",
+            name: "Image Chooser HUD: show / hide",
+            type: "boolean",
+            defaultValue: true,
+            onChange: (newValue) => { hud.setVisibility(newValue); }
+        });
+        app.ui.settings.addSetting({
             id: "ImageChooser.hudpos",
             name: "Image Chooser HUD position (-1 for off)",
             type: "slider",

--- a/js/image_chooser.js
+++ b/js/image_chooser.js
@@ -144,6 +144,19 @@ app.registerExtension({
             onChange: (newValue) => { hud.setVisibility(newValue); }
         });
         app.ui.settings.addSetting({
+            id: "ImageChooser.hudSide",
+            name: "Image Chooser HUD: side",
+            type: "combo",
+            options: [{
+                text:"Left",
+                value: "left"
+            },{
+                text: "Right",
+                value: "right"
+            }],
+            onChange: (newValue) => { hud.setSide(newValue); }
+        })
+        app.ui.settings.addSetting({
             id: "ImageChooser.hudpos",
             name: "Image Chooser HUD: vertical position (from the top)",
             type: "slider",

--- a/js/image_chooser.js
+++ b/js/image_chooser.js
@@ -145,7 +145,7 @@ app.registerExtension({
         });
         app.ui.settings.addSetting({
             id: "ImageChooser.hudSide",
-            name: "Image Chooser HUD: side",
+            name: "Image Chooser HUD: horizontal side",
             type: "combo",
             options: [{
                 text:"Left",
@@ -155,7 +155,19 @@ app.registerExtension({
                 value: "right"
             }],
             onChange: (newValue) => { hud.setSide(newValue); }
-        })
+        });
+        app.ui.settings.addSetting({
+            id: "ImageChooser.hudHPos",
+            name: "Image Chooser HUD: horizontal position (from the selected side)",
+            type: "slider",
+            attrs: {
+                min: 0,
+                max: 500,
+                step: 1
+            },
+            defaultValue: 10,
+            onChange: (newValue) => { hud.moveHorizontalPosition(newValue); } 
+        });
         app.ui.settings.addSetting({
             id: "ImageChooser.hudpos",
             name: "Image Chooser HUD: vertical position (from the top)",
@@ -166,7 +178,7 @@ app.registerExtension({
                 step: 1,
             },
             defaultValue: 10,
-            onChange: (newVal) => { hud.move(newVal); }
+            onChange: (newVal) => { hud.moveVerticalPosition(newVal); }
         });
         app.ui.settings.addSetting({
             id: "ImageChooser.hotkeys",

--- a/js/image_chooser.js
+++ b/js/image_chooser.js
@@ -145,7 +145,7 @@ app.registerExtension({
         });
         app.ui.settings.addSetting({
             id: "ImageChooser.hudpos",
-            name: "Image Chooser HUD: vertical position",
+            name: "Image Chooser HUD: vertical position (from the top)",
             type: "slider",
             attrs: {
                 min: 0,

--- a/js/image_chooser.js
+++ b/js/image_chooser.js
@@ -145,15 +145,15 @@ app.registerExtension({
         });
         app.ui.settings.addSetting({
             id: "ImageChooser.hudpos",
-            name: "Image Chooser HUD position (-1 for off)",
+            name: "Image Chooser HUD: vertical position",
             type: "slider",
             attrs: {
-                min: -1,
+                min: 0,
                 max: 500,
                 step: 1,
             },
             defaultValue: 10,
-            onChange: (newVal, oldVal) => { hud.move(newVal); }
+            onChange: (newVal) => { hud.move(newVal); }
         });
         app.ui.settings.addSetting({
             id: "ImageChooser.hotkeys",

--- a/js/image_chooser.js
+++ b/js/image_chooser.js
@@ -120,7 +120,7 @@ app.registerExtension({
 
         function intercept_queue_triggers() {
             if (app.ui.settings.getSettingValue("ImageChooser.cancelOnQueue", true)) {
-               if (FlowState.paused()) api.interrupt();
+                if (FlowState.paused()) api.interrupt();
             }
         }
 
@@ -141,9 +141,9 @@ app.registerExtension({
             name: "Image Chooser HUD position (-1 for off)",
             type: "slider",
             attrs: {
-              min: -1,
-              max: 500,
-              step: 1,
+                min: -1,
+                max: 500,
+                step: 1,
             },
             defaultValue: 10,
             onChange: (newVal, oldVal) => { hud.move(newVal); }

--- a/js/image_chooser_hud.js
+++ b/js/image_chooser_hud.js
@@ -6,13 +6,16 @@ class HUD {
     #VISIBLE_OPACITY = 0.8;
     #INVISIBLE_OPACITY = 0;
 
+    // define side offset placeholder
+    #sideOffset = 10;
+
     constructor() {
         this.span = $el("span", { style: { color:"white" }, textContent: "" });
         this.hud = $el("div", {
             style: { 
                 "position": "fixed", 
                 "top":"10px", 
-                "left":"10px", 
+                "left": this.#sideOffset + "px", 
                 "border":"thin solid #f66", 
                 "padding":"8px", 
                 "opacity": this.#VISIBLE_OPACITY,
@@ -35,6 +38,16 @@ class HUD {
 
     setVisibility(newVisibility) {
         this.hud.style.opacity = newVisibility ? this.#VISIBLE_OPACITY : this.#INVISIBLE_OPACITY;
+    }
+
+    setSide(newSide) {
+        const oldSide = newSide === "left" ? "right" : "left";
+
+        console.log(this.hud.style[oldSide], this.hud.style[newSide]);
+
+        // swap then remove the value as the side is changed
+        this.hud.style[newSide] = this.#sideOffset + "px";
+        this.hud.style[oldSide] = "";
     }
 
     update() {

--- a/js/image_chooser_hud.js
+++ b/js/image_chooser_hud.js
@@ -6,7 +6,8 @@ class HUD {
     #VISIBLE_OPACITY = 0.8;
     #INVISIBLE_OPACITY = 0;
 
-    // define side offset placeholder
+    // define side and offset placeholders and defaults
+    #side = "left";
     #sideOffset = 10;
 
     constructor() {
@@ -32,7 +33,13 @@ class HUD {
         this.current_node_is_chooser = false;
     }
 
-    move(newtop) {
+    moveHorizontalPosition(newHorizontalOffset) {
+        this.#sideOffset = newHorizontalOffset;
+
+        this.hud.style[this.#side] = this.#sideOffset + "px";
+    }
+
+    moveVerticalPosition(newtop) {
         this.hud.style.top = `${newtop}px`;
     }
 
@@ -41,11 +48,9 @@ class HUD {
     }
 
     setSide(newSide) {
+        this.#side = newSide;
         const oldSide = newSide === "left" ? "right" : "left";
-
-        console.log(this.hud.style[oldSide], this.hud.style[newSide]);
-
-        // swap then remove the value as the side is changed
+        
         this.hud.style[newSide] = this.#sideOffset + "px";
         this.hud.style[oldSide] = "";
     }

--- a/js/image_chooser_hud.js
+++ b/js/image_chooser_hud.js
@@ -2,6 +2,10 @@ import { $el } from "../../scripts/ui.js";
 import { app } from "../../scripts/app.js";
 
 class HUD {
+    // define style "constants"
+    #VISIBLE_OPACITY = 0.8;
+    #INVISIBLE_OPACITY = 0;
+
     constructor() {
         this.span = $el("span", { style: { color:"white" }, textContent: "" });
         this.hud = $el("div", {
@@ -11,7 +15,7 @@ class HUD {
                 "left":"10px", 
                 "border":"thin solid #f66", 
                 "padding":"8px", 
-                "opacity":0.8,
+                "opacity": this.#VISIBLE_OPACITY,
             }},
             [
                 this.span
@@ -27,7 +31,10 @@ class HUD {
 
     move(newtop) {
         this.hud.style.top = `${newtop}px`;
-        this.hud.style.opacity = newtop>=0 ? 0.8 : 0;
+    }
+
+    setVisibility(newVisibility) {
+        this.hud.style.opacity = newVisibility ? this.#VISIBLE_OPACITY : this.#INVISIBLE_OPACITY;
     }
 
     update() {


### PR DESCRIPTION
I added new options for positioning the HUD. The main motivation is to be able to position the HUD away from sidebar ui extensions like ComfyUI-N-Sidebar and ComfyUI Workspace Manager - Comfyspace.

Image Chooser HUD: horizontal side
- options ["Left", "Right"]
- This option toggles the HUD's position based on either the left or right edge of the screen. Left is default.

Image Chooser HUD: horizontal position
- slider values are 0-500 inclusive in increments of 1
- This option sets the number of pixels of offset from the selected edge. 10 px is the default.

Image Chooser HUD: show/hide
- boolean checkbox
- This option breaks out hud visibility from the vertical position setting. true (visible) is the default.

Other changes include:
- updating the range of the vertical position to 0-500 inclusive
- minor whitespace changes
- renamed the original position setting to vertical position including existing functions
  - The original position setting name was not changed to maintain backward-compatibility 