### PR TITLE
Fix default for "mode" in IS_CHANGED

### DIFF
--- a/image_chooser_preview.py
+++ b/image_chooser_preview.py
@@ -27,7 +27,7 @@ class PreviewAndChoose(PreviewImage):
 
     @classmethod
     def IS_CHANGED(cls, id, **kwargs):
-        mode = kwargs.get("mode","")
+        mode = kwargs.get("mode",["Always pause"])
         if (mode[0]!="Repeat last selection" or not id[0] in cls.last_ic): cls.last_ic[id[0]] = random.random()
         return cls.last_ic[id[0]]
 


### PR DESCRIPTION
For the longest time, I've been seeing a `WARNING: string index out of range` warning from ComfyUI with every generation, but it unhelpfully never provided more details.

This fixes the `IS_CHANGED` method. I'm not sure if the default is correct, but I see similar treatment a few lines below.
